### PR TITLE
Deal with the new "is_cal_localtime" element.

### DIFF
--- a/tripit.py
+++ b/tripit.py
@@ -217,7 +217,7 @@ class ResponseHandler(xml.sax.handler.ContentHandler):
                 self._current_content = datetime.date(
                     *(time.strptime(
                         self._current_content, '%Y-%m-%d')[0:3]))
-            elif name.endswith('time'):
+            elif name.endswith('time') and not name.endswith('is_cal_localtime'):
                 self._current_content = datetime.time(
                     *(time.strptime(
                         self._current_content, '%H:%M:%S')[3:6]))


### PR DESCRIPTION
Apparently at some point the response was updated to include:
<is_cal_localtime>true</is_cal_localtime>

This would make:
time.strptime(self._current_content, '%H:%M:%S')[3:6])
fail with "ValueError: time data u'true' does not match format '%H:%M:%S'"

I'm not sure what else might end with 'time', and so I'm simply excluding is_cal_localtime.